### PR TITLE
Update url to point at current geo-ip data

### DIFF
--- a/script/update_geoip
+++ b/script/update_geoip
@@ -3,6 +3,6 @@
 mkdir -p shared
 cd shared
 rm -f GeoLiteCity.dat.gz
-wget -q http://www.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+wget -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
 gunzip -f GeoLiteCity.dat.gz
 


### PR DESCRIPTION
I noticed that the maxmind url was returning a redirect.
This updates the update script to include the new url.
