### PR TITLE
updating .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ base_packaged.*
 .bundle
 log/*.log
 tmp/**/*
+tmp/restart.txt
 vendor/cache/*.gem
 public/javascripts/login_packaged.js
 public/javascripts/show_packaged.js
@@ -28,3 +29,5 @@ public/packages/
 .redcar
 .idea
 tunnlr.yml
+shared/*
+.rbenv-version


### PR DESCRIPTION
While setting up shapedo for development on my laptop using rbenv and pow I found some files floating around.
This patch updates the gitignore to exclude those files from being tracked by git.
