### PR TITLE
syntax change for form_for call in search template

### DIFF
--- a/app/views/searches/index.html.haml
+++ b/app/views/searches/index.html.haml
@@ -25,7 +25,7 @@
 
     -if params[:q]
       .save-search
-        =form_for :search, @search, :url => search_index_path, :html => {:class => "form"} do |f|
+        =form_for @search, :url => search_index_path, :html => {:class => "form"} do |f|
           =f.hidden_field :query
           .field
             =f.label :name, t('searches.index.input_title')


### PR DESCRIPTION
The search form_for appears to be using the old (redundant) :search, @search format. This patch brings it inline with all other use of form_for in Shapado.
