### PR TITLE
Fix Facebook login nil password issue

### DIFF
--- a/lib/multiauth_support.rb
+++ b/lib/multiauth_support.rb
@@ -68,6 +68,11 @@ module MultiauthSupport
           end
         end
 
+        # To handle: Facebook login issue
+        if user.password.blank? && provider =~ /facebook|Facebook/
+          user.password = Devise.friendly_token[0,20]
+        end
+
         if !user.valid? && !user.errors[:login].empty?
           user.login = user.login + "_#{rand(100)}#{rand(100)}#{rand(100)}"
         end


### PR DESCRIPTION
MultiauthSupport#password_required? is not working when user logged in via Facebook.
It won't create a new user record because the password is nil.
